### PR TITLE
Install tkn During Tests

### DIFF
--- a/src/main/java/dev/tekton/plugins/jenkins/tkn/TknBuilder.java
+++ b/src/main/java/dev/tekton/plugins/jenkins/tkn/TknBuilder.java
@@ -59,9 +59,13 @@ public class TknBuilder extends Builder implements SimpleBuildStep {
             // TODO: Add support for Windows
             args.add("tkn");
         } else {
-            Node node = Computer.currentComputer().getNode();
+            Computer computer = workspace.toComputer();
+            if (computer == null) {
+                throw new AbortException("No computer detected - offline?");
+            }
+            Node node = computer.getNode();
             if (node == null) {
-                throw new AbortException("offline?");
+                throw new AbortException("No node detected - offline?");
             }
             tkn = tkn.forNode(node, listener);
             tkn = tkn.forEnvironment(env);

--- a/src/test/java/dev/tekton/plugins/jenkins/tkn/TknBuilderTest.java
+++ b/src/test/java/dev/tekton/plugins/jenkins/tkn/TknBuilderTest.java
@@ -1,14 +1,13 @@
 package dev.tekton.plugins.jenkins.tkn;
 
-import static org.junit.Assert.assertNotNull;
-
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
-import hudson.model.Label;
-import hudson.model.queue.QueueTaskFuture;
+import java.io.IOException;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -19,6 +18,15 @@ public class TknBuilderTest {
     public JenkinsRule jenkins = new JenkinsRule();
 
     final String tknVersion = "v0.31.1";
+
+    @Before
+    public void setUp() {
+        try {
+            TknToolInstallations.configureDefaultTkn(jenkins.getInstance(), tknVersion);
+        } catch (IOException e) {
+            Assert.fail("Failed to configure tkn installer: " + e.getLocalizedMessage());
+        }
+    }
 
     @Test
     public void testConfigRoundtrip() throws Exception {
@@ -34,26 +42,22 @@ public class TknBuilderTest {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         TknBuilder builder = new TknBuilder(tknVersion);
         project.getBuildersList().add(builder);
-        // Simply check that the build was scheduled
-        // Actual builds can fail if tkn is not in the PATH
+        // tkn version should succeed
         // TODO: Test happy/sad paths for tkn existence
-        QueueTaskFuture<FreeStyleBuild> r = project.scheduleBuild2(0);
-        assertNotNull("build was not scheduled", r);
-        jenkins.assertLogContains("tkn version", r.get());
+        FreeStyleBuild build = jenkins.assertBuildStatusSuccess(project.scheduleBuild2(0));
+        jenkins.assertLogContains("tkn version", build);
     }
 
     @Test
     public void testScriptedPipeline() throws Exception {
-        String agentLabel = "my-agent";
-        jenkins.createOnlineSlave(Label.get(agentLabel));
+        // String agentLabel = "my-agent";
+        // jenkins.createOnlineSlave(Label.get(agentLabel));
         WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-scripted-pipeline");
         String pipelineScript = "node {tkn '" + tknVersion + "'}";
         job.setDefinition(new CpsFlowDefinition(pipelineScript, true));
-        // Simply check that the build was scheduled
-        // Actual builds can fail if tkn is not in the PATH
+        // tkn version should succeed
         // TODO: Test happy/sad paths for tkn existence
-        QueueTaskFuture<WorkflowRun> r = job.scheduleBuild2(0);
-        assertNotNull("pipeline run was not scheduled", r);
-        jenkins.assertLogContains("tkn version", r.get());
+        WorkflowRun run = jenkins.assertBuildStatusSuccess(job.scheduleBuild2(0));
+        jenkins.assertLogContains("tkn version", run);
     }
 }

--- a/src/test/java/dev/tekton/plugins/jenkins/tkn/TknToolInstallations.java
+++ b/src/test/java/dev/tekton/plugins/jenkins/tkn/TknToolInstallations.java
@@ -1,0 +1,41 @@
+package dev.tekton.plugins.jenkins.tkn;
+
+import hudson.tools.InstallSourceProperty;
+import hudson.tools.ToolInstaller;
+import hudson.tools.ZipExtractionInstaller;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import jenkins.model.Jenkins;
+
+public class TknToolInstallations {
+
+    public static TknClientInstallation configureDefaultTkn(Jenkins jenkins, String version) throws IOException {
+        Path tkn = Paths.get(System.getProperty("user.dir"), "work", "tools", "tkn", version);
+        if (!tkn.toFile().exists()) {
+            tkn.toFile().mkdirs();
+        }
+        // Create property to auto-install from GitHub tar or zip
+        ToolInstaller installer = new ZipExtractionInstaller(null, getTknUrl(version), null);
+        InstallSourceProperty installProperty = new InstallSourceProperty(Arrays.asList(installer));
+        TknClientInstallation install =
+                new TknClientInstallation(version, tkn.toAbsolutePath().toString(), Arrays.asList(installProperty));
+        jenkins.getDescriptorByType(TknClientInstallation.DescriptorImpl.class).setInstallations(install);
+        return install;
+    }
+
+    public static String getTknUrl(String version) {
+        if (version.startsWith("v")) {
+            version = version.substring(1);
+        }
+        // TODO: Make this a describable, universal installer.
+        String baseUrl = "https://github.com/tektoncd/cli/releases/download";
+        String os = "Linux";
+        String arch = "x86_64";
+        String extension = "tar.gz";
+
+        // https://github.com/tektoncd/cli/releases/download/v0.31.2/tkn_0.31.2_Linux_x86_64.tar.gz
+        return String.format("%1$s/v%2$s/tkn_%2$s_%3$s_%4$s.%5$s", baseUrl, version, os, arch, extension);
+    }
+}


### PR DESCRIPTION
Use the ZipExtractionInstaller to automatically install tkn from GitHub during tests. This allow the TknBuilderTest to reach a "happy path" and report successful build steps.