### PR TITLE
PoC: Run Arbitrary Commands

### DIFF
--- a/src/main/resources/dev/tekton/plugins/jenkins/tkn/TknBuilder/config.jelly
+++ b/src/main/resources/dev/tekton/plugins/jenkins/tkn/TknBuilder/config.jelly
@@ -1,6 +1,9 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:entry title="${%Name}" field="tknName">
+    <f:entry title="Commands" field="commands">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="${%Name}" field="toolVersion">
         <f:textbox />
     </f:entry>
 </j:jelly>

--- a/src/test/java/dev/tekton/plugins/jenkins/tkn/TknBuilderTest.java
+++ b/src/test/java/dev/tekton/plugins/jenkins/tkn/TknBuilderTest.java
@@ -31,16 +31,24 @@ public class TknBuilderTest {
     @Test
     public void testConfigRoundtrip() throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
-        project.getBuildersList().add(new TknBuilder(tknVersion));
+        TknBuilder builder = new TknBuilder();
+        builder.setToolVersion(tknVersion);
+        builder.setCommands("version");
+        project.getBuildersList().add(builder);
         project = jenkins.configRoundtrip(project);
-        jenkins.assertEqualDataBoundBeans(
-                new TknBuilder(tknVersion), project.getBuildersList().get(0));
+
+        TknBuilder expected = new TknBuilder();
+        expected.setToolVersion(tknVersion);
+        expected.setCommands("version");
+        jenkins.assertEqualDataBoundBeans(expected, project.getBuildersList().get(0));
     }
 
     @Test
     public void testBuild() throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
-        TknBuilder builder = new TknBuilder(tknVersion);
+        TknBuilder builder = new TknBuilder();
+        builder.setToolVersion(tknVersion);
+        builder.setCommands("version");
         project.getBuildersList().add(builder);
         // tkn version should succeed
         // TODO: Test happy/sad paths for tkn existence
@@ -53,7 +61,7 @@ public class TknBuilderTest {
         // String agentLabel = "my-agent";
         // jenkins.createOnlineSlave(Label.get(agentLabel));
         WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-scripted-pipeline");
-        String pipelineScript = "node {tkn '" + tknVersion + "'}";
+        String pipelineScript = "node {tkn toolVersion: '" + tknVersion + "', commands: 'version'}";
         job.setDefinition(new CpsFlowDefinition(pipelineScript, true));
         // tkn version should succeed
         // TODO: Test happy/sad paths for tkn existence


### PR DESCRIPTION
Proof of concept to run arbitrary commands from `tkn` via the plugin. Commands are assumed to be space delimeted. For commands to work in practice, appropriate flags need to be set so tkn is non-interactive. The current implementation does not handle non-zero return values.