### PR TITLE
Warn if KUBECONFIG is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # `tkn` Client Plugin
 
-## Introduction
+A Jenkins plugin for running Tekton pipelines with the `tkn` CLI.
 
-A Jenkins plugin for running Tekton pipelines
+## Prerequisites
+
+- A jenkins installation running version 2.401.1.
+- (optional) Install a plugin that supports management of Kubernetes credentials, such as:
+  - [Kubernetes Plugin](https://plugins.jenkins.io/kubernetes/) for full Kubernetes integration.
+  - [Kubernetes CLI Plugin](https://plugins.jenkins.io/kubernetes-cli/) for simple setups.
 
 ## Getting started
+
 
 TODO Tell users how to configure your plugin here, include screenshots, pipeline examples and 
 configuration-as-code examples.

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
       <artifactId>structs</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>kubernetes-cli</artifactId>
+      <version>1.12.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
       <scope>test</scope>

--- a/src/main/java/dev/tekton/plugins/jenkins/tkn/TknBuilder.java
+++ b/src/main/java/dev/tekton/plugins/jenkins/tkn/TknBuilder.java
@@ -102,6 +102,12 @@ public class TknBuilder extends Builder implements SimpleBuildStep {
         if (runCommands == null) {
             runCommands = "version";
         }
+
+        // Warn if KUBECONFIG env var is not set
+        if (!env.containsKey("KUBECONFIG")) {
+            listener.getLogger().println("WARN: no KUBECONFIG provided, using system default kubeconfig credentials.");
+        }
+
         args.add(runCommands.trim().split("\\s"));
         listener.getLogger().println("Running tkn command");
         try {

--- a/src/test/java/dev/tekton/plugins/jenkins/tkn/TknBuilderTest.java
+++ b/src/test/java/dev/tekton/plugins/jenkins/tkn/TknBuilderTest.java
@@ -1,8 +1,16 @@
 package dev.tekton.plugins.jenkins.tkn;
 
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -57,15 +65,43 @@ public class TknBuilderTest {
     }
 
     @Test
-    public void testScriptedPipeline() throws Exception {
+    public void testScriptedPipelineNoKubeconfig() throws Exception {
         // String agentLabel = "my-agent";
         // jenkins.createOnlineSlave(Label.get(agentLabel));
         WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-scripted-pipeline");
-        String pipelineScript = "node {tkn toolVersion: '" + tknVersion + "', commands: 'version'}";
+        String pipelineScript = loadGroovyScript("pipeline-noauth.groovy");
         job.setDefinition(new CpsFlowDefinition(pipelineScript, true));
         // tkn version should succeed
         // TODO: Test happy/sad paths for tkn existence
         WorkflowRun run = jenkins.assertBuildStatusSuccess(job.scheduleBuild2(0));
         jenkins.assertLogContains("tkn version", run);
+        jenkins.assertLogContains("no KUBECONFIG provided", run);
+    }
+
+    @Test
+    public void testScriptedPipelineWithKubeconfig() throws Exception {
+        // String agentLabel = "my-agent";
+        // jenkins.createOnlineSlave(Label.get(agentLabel));
+        CredentialsProvider.lookupStores(jenkins.jenkins)
+                .iterator()
+                .next()
+                .addCredentials(Domain.global(), dummyCredentials("test-kubeconfig"));
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-authed-pipeline");
+
+        String pipelineScript = loadGroovyScript("pipeline-auth.groovy");
+        job.setDefinition(new CpsFlowDefinition(pipelineScript, true));
+        // tkn version should succeed
+        // TODO: Test happy/sad paths for tkn existence
+        WorkflowRun run = jenkins.assertBuildStatusSuccess(job.scheduleBuild2(0));
+        jenkins.assertLogContains("tkn version", run);
+        jenkins.assertLogNotContains("no KUBECONFIG provided", run);
+    }
+
+    public Credentials dummyCredentials(String credId) {
+        return new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credId, "dummy", "test-user", "test-pass");
+    }
+
+    public String loadGroovyScript(String script) throws IOException, URISyntaxException {
+        return Files.readString(Paths.get(getClass().getResource(script).toURI()));
     }
 }

--- a/src/test/resources/dev/tekton/plugins/jenkins/tkn/pipeline-auth.groovy
+++ b/src/test/resources/dev/tekton/plugins/jenkins/tkn/pipeline-auth.groovy
@@ -1,0 +1,5 @@
+node {
+    withKubeConfig([credentialsId: 'test-kubeconfig', serverUrl: 'https://api.test-k8s:6443' ]) {
+        tkn toolVersion: 'v0.31.1', commands: 'version'
+    }
+}

--- a/src/test/resources/dev/tekton/plugins/jenkins/tkn/pipeline-noauth.groovy
+++ b/src/test/resources/dev/tekton/plugins/jenkins/tkn/pipeline-noauth.groovy
@@ -1,0 +1,3 @@
+node {
+    tkn toolVersion: 'v0.31.1', commands: 'version'
+}


### PR DESCRIPTION
Add a warning if the KUBECONFIG environment variable is not set. This is important if developers want/need to provide their own cluster credentials, and not rely on a default kubeconfig file added to the Jenkins build agent environment. Testing is accomplished with the Kubernetes CLI plugin, which provides the `withKubeConfig` wrapper for Pipeline DSL syntax and injects a KUBECONFIG env var.