### PR TITLE
Demo - Pipelines as Code Squared

### DIFF
--- a/demos/openshift/README.md
+++ b/demos/openshift/README.md
@@ -1,0 +1,96 @@
+# Tkn Client Plugin on OpenShift Demo
+
+## Get an OpenShift Cluster
+
+Log into a modeslty sized OpenShift cluster, with at least 2 vCPU and 4Gi of combined free RAM on
+worker nodes. Smaller footprints like
+[OpenShift Local](https://developers.redhat.com/products/openshift-local/overview) or
+[MicroShift](https://microshift.io/) may not have enough resources to run the demo. You can use a
+managed OpenShift such as [Red Hat OpenShift Service on AWS](https://aws.amazon.com/rosa/).
+
+## Deploy OpenShift Pipelines
+
+Use OperatorHub to install OpenShift Pipelines. This can be done in one of two ways:
+
+1. In the OpenShift Admin Console, search for "Red Hat OpenShift Pipelines" in OperatorHub.
+   Click on the icon, and follow the prompts to install the operator.
+
+2. Create the operator Subscription via the command line:
+
+   ```sh
+   $ oc appy -f demos/openshift/tekton/operator-subscription.yaml
+   ```
+
+_Note: these steps must be executed by a cluster administrator_.
+
+## Deploy Jenkins
+
+1. Create a project to deploy Jenkins - example: `jenkins-tkn`
+
+   ```sh
+   $ oc new-project jenkins-tkn
+   ```
+
+   _Note: this may require the user to have elevated permissions._
+
+2. (optional) Build a container image using `build/Dockerfile` from the project root and push it
+   to a container registry. Make sure that your cluster is able to pull images from this registry.
+
+   ```sh
+   $ cd ../..
+   $ export IMAGE_REF="<YOUR-REGISTRY>/<YOUR-ORG>/<YOUR-IMAGE>:<YOUR-TAG>"
+   $ podman build -t $IMAGE_REF <YOUR-REGISTRY>/<YOUR-ORG>/<YOUR-IMAGE>:<YOUR-TAG> \
+   -f demos/openshift/build/Dockerfile .
+   # ... build logs
+   $ podman push $IMAGE_REF
+   ```
+
+3. Import `quay.io/adambkaplan/openshift-jenkins:2.401.1-tkn` (or your build above) as an
+   ImageStream in the `jenkins-tkn` project.
+
+   ```sh
+   # When deploying your own image, replace --from with your image reference
+   $ oc import-image jenkins --from=quay.io/adambkaplan/openshift-jenkins:2.401.1-tkn --confirm
+   ```
+
+3. Deploy the Jenkins ephemeral template using the customized image:
+
+   ```sh
+   $ oc new-app jenkins-ephemeral -p JENKINS_IMAGE_STREAM_TAG="jenkins:latest" -p NAMESPACE="jenkins-tkn"
+   ```
+
+4. In the Jenkins web console, go to "Manage Jenkins -> Tools", then add an automatic installer for
+   the `v0.32.0` tkn CLI release. Use this
+   [link](https://github.com/tektoncd/cli/releases/download/v0.32.0/tkn_0.32.0_Linux_x86_64.tar.gz) for
+   the download URL (Linux x86_64).
+
+   ![tkn automatic tool installion form for Jenkins](/assets/tkn-cli-install.png)
+
+## Create the Tekton Pipeline
+
+1. Create an ImageStream for our simple Tekton pipeline output:
+
+   ```sh
+   $ oc create is golang-ex
+   ```
+
+3. Provision a PVC named `s2i-go` to hold the source code of the build:
+
+   ```sh
+   $ oc apply -f demos/openshift/tekton/pvc-s2i-go.yaml
+   ```
+
+## Run Tekton as Code from Jenkins as Code
+
+1. In the Jenkins admin console, create a new "Pipeline" project (pick a name, such as `tkn-s2i-go`).
+
+2. Under the "Pipeline" configuration section, select "Pipeline script from SCM":
+
+   1. For the repository, type `https://github.com/adambkaplan/tkn-client-plugin.git`
+
+   2. For "Script Path", type `demos/openshift/jenkins/Jenkinsfile`.
+
+3. Save your changes, then return to the project's Jenkins page.
+
+4. On the lefthand panel, click "Build Now" to run the pipeline. You are now running "Pipelines as
+   Code" - squared!

--- a/demos/openshift/build/Dockerfile
+++ b/demos/openshift/build/Dockerfile
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest as builder
+
+COPY pom.xml pom.xml
+COPY .mvn .mvn
+COPY src src
+
+RUN mvn verify
+
+FROM registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.11.0-1686832830.1693366259
+COPY --from=builder /home/default/target/tkn-client-plugin.hpi /opt/openshift/plugins/tkn-client-plugin.jpi

--- a/demos/openshift/jenkins/Jenkinsfile
+++ b/demos/openshift/jenkins/Jenkinsfile
@@ -1,0 +1,11 @@
+pipeline {
+   agent any
+   stages {
+      stage('Build') {
+         steps {
+            checkout scm
+            tkn toolVersion: 'v0.32.0', commands: 'pipeline start -f demos/openshift/tekton/pipeline-s2i-go.yaml -w name=workspace,claimName=s2i-go --showlog --use-param-defaults'
+         }
+      }
+   }
+}

--- a/demos/openshift/tekton/operator-subscription.yaml
+++ b/demos/openshift/tekton/operator-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-pipelines-operator
+  namespace: openshift-operators
+spec:
+  channel: latest
+  name: openshift-pipelines-operator-rh
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/demos/openshift/tekton/pipeline-s2i-go.yaml
+++ b/demos/openshift/tekton/pipeline-s2i-go.yaml
@@ -1,0 +1,49 @@
+﻿apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: s2i-go
+  namespace: jenkins-tkn
+spec:
+  params:
+    - default: 'image-registry.openshift-image-registry.svc:5000/jenkins-tkn/golang-ex'
+      name: IMAGE_NAME
+      type: string
+    - default: 'https://github.com/sclorg/golang-ex.git'
+      name: GIT_REPO
+      type: string
+    - default: master
+      name: GIT_REVISION
+      type: string
+  tasks:
+    - name: fetch-repository
+      params:
+        - name: url
+          value: $(params.GIT_REPO)
+        - name: revision
+          value: $(params.GIT_REVISION)
+        - name: subdirectory
+          value: ''
+        - name: deleteExisting
+          value: 'true'
+      taskRef:
+        kind: ClusterTask
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: workspace
+    - name: build
+      params:
+        - name: IMAGE
+          value: $(params.IMAGE_NAME)
+        - name: TLSVERIFY
+          value: 'false'
+      runAfter:
+        - fetch-repository
+      taskRef:
+        kind: ClusterTask
+        name: s2i-go
+      workspaces:
+        - name: source
+          workspace: workspace
+  workspaces:
+    - name: workspace

--- a/demos/openshift/tekton/pvc-s2i-go.yaml
+++ b/demos/openshift/tekton/pvc-s2i-go.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: s2i-go
+  namespace: jenkins-tkn
+spec:
+  resources:
+    requests:
+      storage: 2Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <changelist>-SNAPSHOT</changelist>
 
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.version>2.401.3</jenkins.version>
+    <jenkins.version>2.401.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>


### PR DESCRIPTION
This demos the tkn-client-plugin on OpenShift, using the OpenShift Pipelines operator and the Jenkins ephemeral template. The demo utilizes an extension of the OpenShift Jenkins image that adds the tkn client plugin (built locally), and has a README with full instructions on how to deploy the demo yourself. The demo is called "Pipelines as Code - Squared" because it uses Jenkins as Code (from a Jenkinsfile) to orchestrate Tekton as Code (from a Pipeline YAML manifest).

To get this to work on OpenShift 4.13, the minimum supported version of Jenkins was downgraded to 2.401.1.